### PR TITLE
Closes #18 - Create SQL Stack 

### DIFF
--- a/iac/regional_stack.py
+++ b/iac/regional_stack.py
@@ -5,6 +5,7 @@ import aws_cdk
 
 from persistence_stack.persistence_stack import PersistenceStack
 from access_stack.access_stack import AccessStack
+from sql_stack.sql_stack import SqlStack
 from config.bucket_attributes import BucketAttributes
 
 
@@ -43,4 +44,12 @@ class RegionalStack(aws_cdk.Stack):
             application_ci=application_ci,
             is_primary_region=is_primary_region,
             bucket=persistence_stack.analytics_bucket,
+        )
+
+        sql_stack = SqlStack(
+            self,
+            "sql_stack",
+            env=env,
+            application_ci=application_ci,
+            output_bucket_retain_policy=False,
         )

--- a/iac/sql_stack/sql_stack.py
+++ b/iac/sql_stack/sql_stack.py
@@ -1,0 +1,53 @@
+import aws_cdk
+
+from aws_cdk import (
+    aws_s3 as s3,
+    RemovalPolicy,
+)
+
+from constructs import Construct
+
+
+class SqlStack(aws_cdk.Stack):
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        env: aws_cdk.Environment,
+        application_ci: str,
+        output_bucket_retain_policy: bool,
+        **kwargs,
+    ) -> None:
+
+        super().__init__(scope, construct_id, env=env, **kwargs)
+
+        removal_policy = RemovalPolicy.DESTROY
+        if output_bucket_retain_policy:
+            removal_policy = RemovalPolicy.RETAIN
+
+        self.analytics_bucket = s3.Bucket(
+            self,
+            "SqlOutputBucket",
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            encryption=s3.BucketEncryption.S3_MANAGED,
+            bucket_name=f"{application_ci}-sql-output-{env.region}",
+            enforce_ssl=True,
+            versioned=False,
+            removal_policy=removal_policy,
+        )
+
+
+# For Athena itself...
+# "There are no official hand-written (L2) constructs for this service yet. Here are some suggestions on how to proceed:"
+# https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_athena/README.html
+
+# Manual steps...
+# 1. Create Workgroup
+#    a. Name
+#    b. Analytics Engine - Athena SQL / automatics upgrades
+#    c. Authentication - AWS IAM Identity Center (W3 SSO)
+#    d. Service Role - Create new
+#    e. Query output S3 bucket
+# 2. Create a database 'aialliance' under data catalog AwsDataCatalog
+# 3. Add tables to database 'aialliance' using Hive SQL. See ./sql folder.

--- a/scripts/delete_all_versioned_s3_objects.sh
+++ b/scripts/delete_all_versioned_s3_objects.sh
@@ -4,8 +4,8 @@
 # but it has no (visible) files in it...
 
 aws s3api delete-objects \
-    --bucket aaa-analytics-us-east-1 \
+    --bucket ${bucket_name} \
     --delete "$(aws s3api list-object-versions \
-    --bucket aaa-analytics-us-east-1 \
+    --bucket ${bucket_name} \
     --output json \
     --query '{Objects: Versions[].{Key:Key,VersionId:VersionId}}')"

--- a/scripts/delete_all_versioned_s3_objects.sh
+++ b/scripts/delete_all_versioned_s3_objects.sh
@@ -4,8 +4,8 @@
 # but it has no (visible) files in it...
 
 aws s3api delete-objects \
-    --bucket ${bucket_name} \
+    --bucket aaa-analytics-us-east-1 \
     --delete "$(aws s3api list-object-versions \
-    --bucket ${bucket_name} \
+    --bucket aaa-analytics-us-east-1 \
     --output json \
     --query '{Objects: Versions[].{Key:Key,VersionId:VersionId}}')"

--- a/scripts/github_analytics.sql
+++ b/scripts/github_analytics.sql
@@ -1,0 +1,55 @@
+drop table aialliance.github_analytics
+
+/* Table definition */
+/* Need to review all of these, as some are perpetually missing*/
+CREATE EXTERNAL TABLE IF NOT EXISTS aialliance.github_analytics(
+	timestamp_utc timestamp,
+	repository_name string,
+    stars int,
+    watchers int,
+    forks_total int,
+    open_issues_total int,   
+    network_count int,
+    size_kb int,
+    language string,
+    created_at_utc timestamp,
+    pushed_at_utc timestamp,
+    archived boolean,
+    disabled boolean,        
+    has_issues boolean,
+    has_projects boolean,   
+    has_wiki boolean,
+    has_pages boolean,
+    has_downloads boolean,
+    has_discussions boolean,
+    license string,
+    contributors_count_total int,
+    releases_count_tota int,
+    forks_new_last_period int,
+    contributors_additions_recent_weeks int,
+    traffic_views_last_day_total int,
+    traffic_views_last_day_unique int,
+    traffic_clones_last_day_total int,
+    traffic_clones_last_day_unique int,
+    traffic_top_referrers_date ARRAY <string>,
+    /*traffic_top_paths_data ARRAY <string>,*/
+    issues_opened_last_period int,
+    issues_closed_last_period int,
+    prs_opened_last_period int,
+    prs_closed_last_period int,
+    prs_merged_last_period int,
+    issue_comments_last_period int,
+    pr_comments_last_period int,
+    discussions_opened_last_period int,
+    discussions_comments_last_period int
+)
+partitioned by (service string, repository string, `date` date)
+STORED AS PARQUET
+LOCATION "s3://<bucket>/"
+
+
+/* Need to execute this to process new partitions*/
+MSCK REPAIR TABLE aialliance.github_analytics
+
+/* Test */
+select * from aialliance.github_analytics order by timestamp_utc desc

--- a/scripts/grafana_executon_role.json
+++ b/scripts/grafana_executon_role.json
@@ -1,0 +1,62 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AthenaQueryAccess",
+            "Effect": "Allow",
+            "Action": [
+                "athena:ListDatabases",
+                "athena:ListDataCatalogs",
+                "athena:ListWorkGroups",
+                "athena:GetDatabase",
+                "athena:GetDataCatalog",
+                "athena:GetQueryExecution",
+                "athena:GetQueryResults",
+                "athena:GetTableMetadata",
+                "athena:GetWorkGroup",
+                "athena:ListTableMetadata",
+                "athena:StartQueryExecution",
+                "athena:StopQueryExecution"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "GlueReadAccess",
+            "Effect": "Allow",
+            "Action": [
+                "glue:GetDatabase",
+                "glue:GetDatabases",
+                "glue:GetTable",
+                "glue:GetTables",
+                "glue:GetPartition",
+                "glue:GetPartitions",
+                "glue:BatchGetPartition"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:ListBucketMultipartUploads",
+                "s3:ListMultipartUploadParts",
+                "s3:AbortMultipartUpload",
+                "s3:CreateBucket",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::aws-athena-query-results-*",   # default bucket, if created
+                "arn:aws:s3:::<sql output bucket>,
+                "arn:aws:s3:::<sql output bucket>/*",
+                "arn:aws:s3:::<analytics bucket>",
+                "arn:aws:s3:::<analytics bucket>/*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# PR Template: New Function or Feature

## Description of Changes
Closes #18 Create SQL Stack. 
Unfortunately, there are no aws cdk L2 constructs for Athena. Fortunately, configuring it is not complicated using the UI. 
The SQL stack now only consists of a single S3 bucket that is needed to capture the S3 output. We create two: on in the analytics primary region: us-east-2 and the backup in us-east-1. Several improvements on these buckets will be made in a future PR, including applying a short retention policy to keep the buckets from filling.

In addition, the steps to manually configure Athena are at the bottom of the stack deployment file for future reference. If AWS gets around to adding Athena to cdk, we can replace that with cdk code. 

Finally - the Hive SQL (Athena is powered by Hive) to construct the github analytics table is included. This would also be added at Athena deploy time with cdk. Added here so it can be manually executed until Athena cdk comes online.

Also added is the IAM role for Grafana - which is outside the scope of this PR (it will be in a future presentation_stack PR) but I am adding it here because it was difficult to construct, and I am paranoid I am going to lose it.

## Related Issues
NA

## Testing Performed
Manually tested using SQL / the AWS UI / Grafana

## Code Changes
See above

## Example Usage
NA

## Checklist
Confirm that the following have been completed:

* [X] All new functions have been documented in the `docs/` directory
* [X] Unit tests have been added for new functions
* [X] Code follows the existing style and convention
* [X] API keys or sensitive information have been removed

## Additional Context
NA